### PR TITLE
Added necessary warning to instructions

### DIFF
--- a/src/main/site/_docs/setup-gradle.md
+++ b/src/main/site/_docs/setup-gradle.md
@@ -81,6 +81,8 @@ test {
     useTestNG()
 }
 {% endhighlight %}
+
+> Warning: This tutorial uses the TestNG unit test library. If you want to use JUnit, you will have to remove the above lines from your build.gradle file.
     
 Of course JUnit is also supported. This is all for build configuration settings. We can move on to writing some Citrus integration tests. The Java test classes
 usually go to the **src/test/java** directory.


### PR DESCRIPTION
Users are not told anywhere that they have to remove the "useTestNG()" line in order for their JUnit tests to work properly when run with Gradle. I added a warning to let readers know, so that at least they are told once. This would have saved me hours...